### PR TITLE
convert to an actual overwrite for compatibility + some other small changes

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,7 +12,7 @@ jobs:
       matrix:
         # Use these Java versions
         java: [
-          16    # Minimum supported by Minecraft
+          17    # Minimum supported by Minecraft
         ]
         # and run on both Linux and Windows
         os: [ubuntu-20.04, windows-latest]
@@ -32,7 +32,7 @@ jobs:
       - name: build
         run: ./gradlew build
       - name: capture build artifacts
-        if: ${{ runner.os == 'Linux' && matrix.java == '16' }} # Only upload artifacts built from latest java on one OS
+        if: ${{ runner.os == 'Linux' && matrix.java == '17' }} # Only upload artifacts built from latest java on one OS
         uses: actions/upload-artifact@v2
         with:
           name: Artifacts

--- a/build.gradle
+++ b/build.gradle
@@ -1,10 +1,11 @@
 plugins {
 	id 'fabric-loom' version '0.10-SNAPSHOT'
+	id 'io.github.juuxel.loom-quiltflower-mini' version '1.+'
 	id 'maven-publish'
 }
 
-sourceCompatibility = JavaVersion.VERSION_16
-targetCompatibility = JavaVersion.VERSION_16
+sourceCompatibility = JavaVersion.VERSION_17
+targetCompatibility = JavaVersion.VERSION_17
 
 archivesBaseName = project.archives_base_name
 version = project.mod_version
@@ -47,7 +48,7 @@ tasks.withType(JavaCompile).configureEach {
 	it.options.encoding = "UTF-8"
 
 	// Minecraft 1.17 (21w19a) upwards uses Java 16.
-	it.options.release = 16
+	it.options.release = 17
 }
 
 java {

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,9 +1,7 @@
 pluginManagement {
     repositories {
-        maven {
-            name = 'Fabric'
-            url = 'https://maven.fabricmc.net/'
-        }
+        maven { url = 'https://maven.fabricmc.net/' }
+        maven { url = 'https://server.bbkr.space/artifactory/libs-release/' }
         gradlePluginPortal()
     }
 }

--- a/src/main/java/audaki/cart_engine/mixin/AbstractMinecartEntityMixin.java
+++ b/src/main/java/audaki/cart_engine/mixin/AbstractMinecartEntityMixin.java
@@ -51,7 +51,7 @@ public abstract class AbstractMinecartEntityMixin extends Entity {
      * @reason modify minecart behavior
      */
     @Overwrite
-    protected void moveOnRail(BlockPos pos, BlockState state) {
+    public void moveOnRail(BlockPos pos, BlockState state) {
         this.onLanding();
         double d = this.getX();
         double e = this.getY();

--- a/src/main/java/audaki/cart_engine/mixin/AbstractMinecartEntityMixin.java
+++ b/src/main/java/audaki/cart_engine/mixin/AbstractMinecartEntityMixin.java
@@ -14,10 +14,8 @@ import net.minecraft.entity.vehicle.AbstractMinecartEntity;
 import net.minecraft.util.math.*;
 import net.minecraft.world.World;
 import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Overwrite;
 import org.spongepowered.asm.mixin.Shadow;
-import org.spongepowered.asm.mixin.injection.At;
-import org.spongepowered.asm.mixin.injection.Inject;
-import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
 import java.util.ArrayList;
 import java.util.HashSet;
@@ -25,7 +23,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.BiFunction;
 import java.util.function.Supplier;
 
-@Mixin(AbstractMinecartEntity.class)
+@Mixin(value = AbstractMinecartEntity.class, priority = 500) // lower value, higher priority - apply first so other mods can still mixin
 public abstract class AbstractMinecartEntityMixin extends Entity {
     public AbstractMinecartEntityMixin(EntityType<?> type, World world) {
         super(type, world);
@@ -48,19 +46,13 @@ public abstract class AbstractMinecartEntityMixin extends Entity {
         return null;
     }
 
-    @Inject(at = @At("HEAD"), method = "moveOnRail", cancellable = true)
-    public void moveOnRailOverwrite(BlockPos pos, BlockState state, CallbackInfo ci) {
-
-//        if (this.hasPassengers() && this.getVelocity().horizontalLength() > 0.09) {
-//            System.out.println("Momentum: " + (int) this.getX() + " -> " + this.getVelocity().horizontalLength() + " m/t");
-//        }
-
-        this.modifiedMoveOnRail(pos, state);
-        ci.cancel();
-    }
-
-    private void modifiedMoveOnRail(BlockPos pos, BlockState state) {
-        this.fallDistance = 0.0F;
+    /**
+     * @author audaki
+     * @reason modify minecart behavior
+     */
+    @Overwrite
+    protected void moveOnRail(BlockPos pos, BlockState state) {
+        this.onLanding();
         double d = this.getX();
         double e = this.getY();
         double f = this.getZ();

--- a/src/main/resources/audaki_cart_engine.mixins.json
+++ b/src/main/resources/audaki_cart_engine.mixins.json
@@ -2,12 +2,8 @@
   "required": true,
   "minVersion": "0.8",
   "package": "audaki.cart_engine.mixin",
-  "compatibilityLevel": "JAVA_16",
+  "compatibilityLevel": "JAVA_17",
   "mixins": [
-    "AbstractMinecartEntityMixin"
-  ],
-  "client": [],
-  "server": [
     "AbstractMinecartEntityMixin"
   ],
   "injectors": {

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -25,6 +25,6 @@
     "fabricloader": ">=0.12.8",
     "fabric": "*",
     "minecraft": "1.18.x",
-    "java": ">=16"
+    "java": ">=17"
   }
 }


### PR DESCRIPTION
- converted the main mixin to an actual overwrite instead of a head-n-cancel. Other mods injecting to the same place should now be compatible if their mixins are set up well.
- updated required java to 17 in a couple places, as that's what MC needs now
- added QuiltFlower for better decompiled code (`genSourcesWithQuiltflower` task)
- clean up mixins.json, removing redundant blocks