### PR TITLE
Backport to 1.20

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -33,6 +33,6 @@ java {
 
 jar {
 	from("LICENSE") {
-		rename { "${it}_${project.archives_base_name}"}
+		rename { "${it}_${project.base.archivesName.get()}" }
 	}
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -3,7 +3,7 @@ org.gradle.jvmargs=-Xmx4G
 org.gradle.parallel=true
 
 # Fabric Properties, @see https://fabricmc.net/develop
-minecraft_version=1.20.3
+minecraft_version=1.20.1
 loader_version=0.15.11
 
 # Mod Properties

--- a/src/main/java/audaki/cart_engine/mixin/AbstractMinecartEntityMixin.java
+++ b/src/main/java/audaki/cart_engine/mixin/AbstractMinecartEntityMixin.java
@@ -13,7 +13,6 @@ import net.minecraft.world.entity.MoverType;
 import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.entity.vehicle.AbstractMinecart;
 import net.minecraft.world.entity.vehicle.AbstractMinecart.Type;
-import net.minecraft.world.entity.vehicle.VehicleEntity;
 import net.minecraft.world.level.Level;
 import net.minecraft.world.level.block.BaseRailBlock;
 import net.minecraft.world.level.block.Blocks;
@@ -30,12 +29,11 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
-import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.BiFunction;
 import java.util.function.Supplier;
 
 @Mixin(AbstractMinecart.class)
-public abstract class AbstractMinecartEntityMixin extends VehicleEntity {
+public abstract class AbstractMinecartEntityMixin extends Entity {
     public AbstractMinecartEntityMixin(EntityType<?> type, Level level) {
         super(type, level);
     }

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -29,7 +29,7 @@
   ],
   "depends": {
     "fabricloader": "*",
-    "minecraft": ">=1.20.3",
+    "minecraft": ">=1.20",
     "java": ">=17"
   },
   "suggests": {


### PR DESCRIPTION
The only change necessary to run the mod on versions as low as 1.20 is changing `AbstractMinecartEntityMixin` to extend `Entity` instead of `VehicleEntity`, since the latter class doesn't exist on versions below 1.20.2. No other changes are necessary :D

It's possible the mod will run on versions below 1.20, but it's as of yet untested.

Nitpicks:
- `gradle.properties` builds against 1.20.1 instead of 1.20, since 1.20.1 is newer and the two versions are otherwise functionally identical
- `build.gradle` was updated to match [FabricMC/fabric-example-mod](https://github.com/FabricMC/fabric-example-mod) ([source](https://github.com/FabricMC/fabric-example-mod/blob/2930d654410f005963a3c695860a3f5ca93d60d7/build.gradle#L66-L70))