### PR TITLE
Use the vanilla gamerule minecartMaxSpeed for non rideable minecarts

### DIFF
--- a/src/main/java/audaki/cart_engine/mixin/GameRulesMixin.java
+++ b/src/main/java/audaki/cart_engine/mixin/GameRulesMixin.java
@@ -1,0 +1,16 @@
+package audaki.cart_engine.mixin;
+
+import com.llamalad7.mixinextras.injector.ModifyExpressionValue;
+import net.minecraft.world.flag.FeatureFlag;
+import net.minecraft.world.flag.FeatureFlags;
+import net.minecraft.world.level.GameRules;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+
+@Mixin(GameRules.class)
+public abstract class GameRulesMixin {
+    @ModifyExpressionValue(method = "<clinit>", at = @At(value = "FIELD", target = "Lnet/minecraft/world/flag/FeatureFlags;MINECART_IMPROVEMENTS:Lnet/minecraft/world/flag/FeatureFlag;"))
+    private static FeatureFlag enableMinecartSpeed(FeatureFlag featureFlag) {
+        return FeatureFlags.VANILLA;
+    }
+}

--- a/src/main/java/audaki/cart_engine/mixin/NewMinecartBehaviorMixin.java
+++ b/src/main/java/audaki/cart_engine/mixin/NewMinecartBehaviorMixin.java
@@ -19,11 +19,10 @@ public abstract class NewMinecartBehaviorMixin extends MinecartBehavior {
 
     @Inject(at = @At("HEAD"), method = "getMaxSpeed", cancellable = true)
     public void _getMaxSpeed(ServerLevel level, CallbackInfoReturnable<Double> cir) {
-        int speedBlocksPerSecond = 8;
         if (minecart.isRideable()) {
-            speedBlocksPerSecond = level.getGameRules().getInt(AceGameRules.ACE_CART_SPEED);;
+            int speedBlocksPerSecond = level.getGameRules().getInt(AceGameRules.ACE_CART_SPEED);
+            cir.setReturnValue(speedBlocksPerSecond * (this.minecart.isInWater() ? 0.5 : 1.0) / 20.0);
+            cir.cancel();
         }
-        cir.setReturnValue(speedBlocksPerSecond * (this.minecart.isInWater() ? 0.5 : 1.0) / 20.0);
-        cir.cancel();
     }
 }

--- a/src/main/resources/audaki_cart_engine.mixins.json
+++ b/src/main/resources/audaki_cart_engine.mixins.json
@@ -5,6 +5,7 @@
   "compatibilityLevel": "JAVA_17",
   "mixins": [
     "AbstractMinecartMixin",
+    "GameRulesMixin",
     "NewMinecartBehaviorMixin"
   ],
   "injectors": {


### PR DESCRIPTION
This removes the feature flag check for that gamerule, and only modifies the result of getMaxSpeed for rideable minecarts. By default, this has the same behaviour as before.