### PR TITLE
Fixed so old redstone mechanics still work

### DIFF
--- a/src/main/java/audaki/cart_engine/mixin/AbstractMinecartMixin.java
+++ b/src/main/java/audaki/cart_engine/mixin/AbstractMinecartMixin.java
@@ -2,31 +2,28 @@ package audaki.cart_engine.mixin;
 
 import net.minecraft.world.entity.EntityType;
 import net.minecraft.world.entity.vehicle.*;
-import net.minecraft.world.level.Level;
 import org.spongepowered.asm.mixin.*;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 
+
 @Mixin(AbstractMinecart.class)
 public abstract class AbstractMinecartMixin extends VehicleEntity {
 
+    @Unique
+    private static final ThreadLocal<Boolean> IS_RIDEABLE_CONTEXT = ThreadLocal.withInitial(() -> false);
+
     @Shadow
     public abstract boolean isRideable();
-
-    @Shadow
-    public abstract boolean isFurnace();
-
-    @Shadow
-    private boolean onRails;
 
     @Mutable
     @Final
     @Shadow
     private MinecartBehavior behavior;
 
-    public AbstractMinecartMixin(EntityType<?> type, Level level) {
+    public AbstractMinecartMixin(EntityType<?> type, net.minecraft.world.level.Level level) {
         super(type, level);
     }
 
@@ -34,7 +31,9 @@ public abstract class AbstractMinecartMixin extends VehicleEntity {
     protected void juiceUpBehavior() {
         if (this.behavior instanceof OldMinecartBehavior) {
             AbstractMinecart instance = (AbstractMinecart) (Object) this;
-            this.behavior = new NewMinecartBehavior(instance);
+            if (instance.isRideable()) {
+                this.behavior = new NewMinecartBehavior(instance);
+            }
         }
     }
 
@@ -45,12 +44,18 @@ public abstract class AbstractMinecartMixin extends VehicleEntity {
 
     @Inject(at = @At("HEAD"), method = "tick")
     public void _tick(CallbackInfo ci) {
+        IS_RIDEABLE_CONTEXT.set(this.isRideable());
         this.juiceUpBehavior();
     }
 
+    @Inject(at = @At("RETURN"), method = "tick")
+    public void _tickEnd(CallbackInfo ci) {
+        IS_RIDEABLE_CONTEXT.set(false);
+    }
+
     @Inject(at = @At("HEAD"), method = "useExperimentalMovement", cancellable = true)
-    private static void _useExperimentalMovement(Level level, CallbackInfoReturnable<Boolean> cir) {
-        cir.setReturnValue(true);
+    private static void _useExperimentalMovement(net.minecraft.world.level.Level level, CallbackInfoReturnable<Boolean> cir) {
+        cir.setReturnValue(IS_RIDEABLE_CONTEXT.get());
         cir.cancel();
     }
 }


### PR DESCRIPTION
Fixed issue with all minecarts using new physics which broke a lot of redstone contraptions. This version v1.0 makes it so player minecarts use new physics and the speeds can be changed and other minecarts use the old physics and do 8b/s. Working on making that changeble too.

How the fix works is that it checks if a minecart is ridable, if it is it tells the minecart to use new physics and if not use the old one. Because the experimental status is global variable we have to make a ThreadLocal and put the information here so the global variable dosent override the minecarts we want to use old physics.

So this unfortunately removes the toggle speed for minecarts which arent player ridden, however redstone still works like it did before and the player speed can be changed to high without problem.

I have tested the build and it works, so all the redstone issues mentionen in #58 #68 are fixed. 