### PR TITLE
Better halting at high speeds

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -3,14 +3,15 @@ org.gradle.jvmargs=-Xmx4G
 org.gradle.parallel=true
 
 # Fabric Properties, @see https://fabricmc.net/develop
-minecraft_version=1.21.6
-loader_version=0.16.14
-loom_version=1.10-SNAPSHOT
+minecraft_version=1.21.7
+yarn_mappings=1.21.7+build.8
+loader_version=0.17.2
+loom_version=1.11-SNAPSHOT
 
 # Fabric API
-fabric_version=0.128.1+1.21.6
+fabric_version=0.129.0+1.21.7
 
 # Mod Properties
-mod_version = 4.2.1
+mod_version = 4.3.0
 maven_group = audaki.minecraft
 archives_base_name = ACE

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.12-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.14-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/src/main/java/audaki/cart_engine/AceGameRules.java
+++ b/src/main/java/audaki/cart_engine/AceGameRules.java
@@ -25,7 +25,7 @@ public class AceGameRules {
         MINECART_HALT_SPEED_THRESHOLD = GameRuleRegistry.register("minecartHaltSpeedThreshold",
                 GameRules.Category.PLAYER,
                 GameRuleFactory.createIntRule(3));
-        MINECART_HALT_SPEED_MULTIPLIER = GameRuleRegistry.register("minecartHaltSpeedModifier",
+        MINECART_HALT_SPEED_MULTIPLIER = GameRuleRegistry.register("minecartHaltSpeedMultiplier",
                 GameRules.Category.PLAYER,
                 GameRuleFactory.createIntRule(50));
     }

--- a/src/main/java/audaki/cart_engine/AceGameRules.java
+++ b/src/main/java/audaki/cart_engine/AceGameRules.java
@@ -9,6 +9,8 @@ public class AceGameRules {
     public static GameRules.Key<GameRules.IntegerValue> MINECART_MAX_SPEED_PLAYER_RIDER;
     public static GameRules.Key<GameRules.IntegerValue> MINECART_MAX_SPEED_OTHER_RIDER;
     public static GameRules.Key<GameRules.IntegerValue> MINECART_MAX_SPEED_EMPTY_RIDER;
+    public static GameRules.Key<GameRules.IntegerValue> MINECART_HALT_SPEED_THRESHOLD;
+    public static GameRules.Key<GameRules.IntegerValue> MINECART_HALT_SPEED_MULTIPLIER;
 
     public static void register() {
         MINECART_MAX_SPEED_PLAYER_RIDER = GameRuleRegistry.register("minecartMaxSpeedPlayerRider",
@@ -20,5 +22,11 @@ public class AceGameRules {
         MINECART_MAX_SPEED_EMPTY_RIDER = GameRuleRegistry.register("minecartMaxSpeedEmptyRider",
                 GameRules.Category.PLAYER,
                 GameRuleFactory.createIntRule(0));
+        MINECART_HALT_SPEED_THRESHOLD = GameRuleRegistry.register("minecartHaltSpeedThreshold",
+                GameRules.Category.PLAYER,
+                GameRuleFactory.createIntRule(3));
+        MINECART_HALT_SPEED_MULTIPLIER = GameRuleRegistry.register("minecartHaltSpeedModifier",
+                GameRules.Category.PLAYER,
+                GameRuleFactory.createIntRule(50));
     }
 }

--- a/src/main/java/audaki/cart_engine/mixin/NewMinecartBehaviorMixin.java
+++ b/src/main/java/audaki/cart_engine/mixin/NewMinecartBehaviorMixin.java
@@ -3,19 +3,21 @@ package audaki.cart_engine.mixin;
 import audaki.cart_engine.AceGameRules;
 import net.minecraft.server.level.ServerLevel;
 import net.minecraft.world.entity.Entity;
-import net.minecraft.world.entity.LivingEntity;
 import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.entity.vehicle.AbstractMinecart;
 import net.minecraft.world.entity.vehicle.MinecartBehavior;
 import net.minecraft.world.entity.vehicle.NewMinecartBehavior;
-import net.minecraft.world.level.GameRules;
+import net.minecraft.world.level.block.Blocks;
+import net.minecraft.world.level.block.PoweredRailBlock;
+import net.minecraft.world.level.block.state.BlockState;
+import net.minecraft.world.phys.Vec3;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Unique;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.Redirect;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 
-import java.util.function.Consumer;
 import java.util.function.IntConsumer;
 
 @Mixin(NewMinecartBehavior.class)
@@ -24,6 +26,9 @@ public abstract class NewMinecartBehaviorMixin extends MinecartBehavior {
     protected NewMinecartBehaviorMixin(AbstractMinecart abstractMinecart) {
         super(abstractMinecart);
     }
+
+    @Unique
+    private final ServerLevel level = (ServerLevel) ((NewMinecartBehavior) (Object) this).level();
 
     @Inject(at = @At("HEAD"), method = "getMaxSpeed", cancellable = true)
     public void _getMaxSpeed(ServerLevel level, CallbackInfoReturnable<Double> cir) {
@@ -51,5 +56,19 @@ public abstract class NewMinecartBehaviorMixin extends MinecartBehavior {
         }
 
         setSpeed.accept(level.getGameRules().getInt(AceGameRules.MINECART_MAX_SPEED_OTHER_RIDER));
+    }
+
+    @Redirect(
+        method = "calculateTrackSpeed(Lnet/minecraft/server/level/ServerLevel;Lnet/minecraft/world/phys/Vec3;Lnet/minecraft/world/entity/vehicle/NewMinecartBehavior$TrackIteration;Lnet/minecraft/core/BlockPos;Lnet/minecraft/world/level/block/state/BlockState;Lnet/minecraft/world/level/block/state/properties/RailShape;)Lnet/minecraft/world/phys/Vec3;",
+        at = @At(value = "INVOKE", target = "Lnet/minecraft/world/entity/vehicle/NewMinecartBehavior;calculateHaltTrackSpeed(Lnet/minecraft/world/phys/Vec3;Lnet/minecraft/world/level/block/state/BlockState;)Lnet/minecraft/world/phys/Vec3;")
+    )
+    public Vec3 calculateHaltTrackSpeed(NewMinecartBehavior instance, Vec3 vec3, BlockState blockState) {
+        if (blockState.is(Blocks.POWERED_RAIL) && !(Boolean)blockState.getValue(PoweredRailBlock.POWERED)) {
+            return vec3.length() * 100 < level.getGameRules().getInt(AceGameRules.MINECART_HALT_SPEED_THRESHOLD)
+                    ? Vec3.ZERO
+                    : vec3.scale(level.getGameRules().getInt(AceGameRules.MINECART_HALT_SPEED_MULTIPLIER) / 100d);
+        } else {
+            return vec3;
+        }
     }
 }

--- a/src/main/java/audaki/cart_engine/mixin/NewMinecartBehaviorMixin.java
+++ b/src/main/java/audaki/cart_engine/mixin/NewMinecartBehaviorMixin.java
@@ -10,7 +10,6 @@ import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.phys.Vec3;
 import net.minecraft.world.entity.vehicle.minecart.*;
 import org.spongepowered.asm.mixin.Mixin;
-import org.spongepowered.asm.mixin.Unique;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.Redirect;
@@ -24,9 +23,6 @@ public abstract class NewMinecartBehaviorMixin extends MinecartBehavior {
     protected NewMinecartBehaviorMixin(AbstractMinecart abstractMinecart) {
         super(abstractMinecart);
     }
-
-    @Unique
-    private final ServerLevel level = (ServerLevel) ((NewMinecartBehavior) (Object) this).level();
 
     @Inject(at = @At("HEAD"), method = "getMaxSpeed", cancellable = true)
     public void _getMaxSpeed(ServerLevel level, CallbackInfoReturnable<Double> cir) {
@@ -61,10 +57,11 @@ public abstract class NewMinecartBehaviorMixin extends MinecartBehavior {
         at = @At(value = "INVOKE", target = "Lnet/minecraft/world/entity/vehicle/minecart/NewMinecartBehavior;calculateHaltTrackSpeed(Lnet/minecraft/world/phys/Vec3;Lnet/minecraft/world/level/block/state/BlockState;)Lnet/minecraft/world/phys/Vec3;")
     )
     public Vec3 calculateHaltTrackSpeed(NewMinecartBehavior instance, Vec3 vec3, BlockState blockState) {
+        if (!(level() instanceof ServerLevel serverLevel)) return vec3;
         if (blockState.is(Blocks.POWERED_RAIL) && !(Boolean)blockState.getValue(PoweredRailBlock.POWERED)) {
-            return vec3.length() * 100 < level.getGameRules().get(AceGameRules.MINECART_HALT_SPEED_THRESHOLD)
+            return vec3.length() * 100 < serverLevel.getGameRules().get(AceGameRules.MINECART_HALT_SPEED_THRESHOLD)
                     ? Vec3.ZERO
-                    : vec3.scale(level.getGameRules().get(AceGameRules.MINECART_HALT_SPEED_MULTIPLIER) / 100d);
+                    : vec3.scale(serverLevel.getGameRules().get(AceGameRules.MINECART_HALT_SPEED_MULTIPLIER) / 100d);
         } else {
             return vec3;
         }

--- a/src/main/java/audaki/cart_engine/mixin/NewMinecartBehaviorMixin.java
+++ b/src/main/java/audaki/cart_engine/mixin/NewMinecartBehaviorMixin.java
@@ -4,15 +4,13 @@ import audaki.cart_engine.AceGameRules;
 import net.minecraft.server.level.ServerLevel;
 import net.minecraft.world.entity.Entity;
 import net.minecraft.world.entity.player.Player;
-import net.minecraft.world.entity.vehicle.AbstractMinecart;
-import net.minecraft.world.entity.vehicle.MinecartBehavior;
-import net.minecraft.world.entity.vehicle.NewMinecartBehavior;
 import net.minecraft.world.level.block.Blocks;
 import net.minecraft.world.level.block.PoweredRailBlock;
 import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.phys.Vec3;
 import net.minecraft.world.entity.vehicle.minecart.*;
 import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Unique;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.Redirect;
@@ -59,8 +57,8 @@ public abstract class NewMinecartBehaviorMixin extends MinecartBehavior {
     }
 
     @Redirect(
-        method = "calculateTrackSpeed(Lnet/minecraft/server/level/ServerLevel;Lnet/minecraft/world/phys/Vec3;Lnet/minecraft/world/entity/vehicle/NewMinecartBehavior$TrackIteration;Lnet/minecraft/core/BlockPos;Lnet/minecraft/world/level/block/state/BlockState;Lnet/minecraft/world/level/block/state/properties/RailShape;)Lnet/minecraft/world/phys/Vec3;",
-        at = @At(value = "INVOKE", target = "Lnet/minecraft/world/entity/vehicle/NewMinecartBehavior;calculateHaltTrackSpeed(Lnet/minecraft/world/phys/Vec3;Lnet/minecraft/world/level/block/state/BlockState;)Lnet/minecraft/world/phys/Vec3;")
+        method = "calculateTrackSpeed(Lnet/minecraft/server/level/ServerLevel;Lnet/minecraft/world/phys/Vec3;Lnet/minecraft/world/entity/vehicle/minecart/NewMinecartBehavior$TrackIteration;Lnet/minecraft/core/BlockPos;Lnet/minecraft/world/level/block/state/BlockState;Lnet/minecraft/world/level/block/state/properties/RailShape;)Lnet/minecraft/world/phys/Vec3;",
+        at = @At(value = "INVOKE", target = "Lnet/minecraft/world/entity/vehicle/minecart/NewMinecartBehavior;calculateHaltTrackSpeed(Lnet/minecraft/world/phys/Vec3;Lnet/minecraft/world/level/block/state/BlockState;)Lnet/minecraft/world/phys/Vec3;")
     )
     public Vec3 calculateHaltTrackSpeed(NewMinecartBehavior instance, Vec3 vec3, BlockState blockState) {
         if (blockState.is(Blocks.POWERED_RAIL) && !(Boolean)blockState.getValue(PoweredRailBlock.POWERED)) {


### PR DESCRIPTION
_Updated for 1.21.11_

I added game rules to configure how fast a minecart will brake on non-powered rails.

Because of Minecraft only supporting integers in game rules, these work as percentages.

minecartHaltSpeedThreshold defines at which speed the minecart stops moving if on non-powered rails.
Default; 3

minecartHaltSpeedMultiplier defines by which velocity of the minecarts speed gets multiplied if halting on non-powered rails.
Default; 50
